### PR TITLE
Remove truncation and legacy posts from RSS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,4 @@ machine:
 test:
   post:
     - npm run build
-    - bundle exec htmlproofer ./dist --check-opengraph true --check-html true --http-status-ignore '408,301,0,530' --url-ignore '/patrickmarsceill.com/' --empty-alt-ignore true
+    - bundle exec htmlproofer ./dist --check-opengraph true --check-html true --http-status-ignore '408,301,403,0,530' --url-ignore '/patrickmarsceill.com/' --empty-alt-ignore true

--- a/src/_posts/legacy/2013-01-14-building-my-desk-part-one-the-frame.md
+++ b/src/_posts/legacy/2013-01-14-building-my-desk-part-one-the-frame.md
@@ -21,7 +21,7 @@ About a month ago, I stumbled upon <a href="http://spacekat.github.com">Jessica'
 
 Unlike Jessica's desk, I didn't want mine to be that of the standing variety.  I did some research and found <a href="http://www.apartmenttherapy.com/look-desks-and-68448">a few photos of other sitting desks that people had made out of plumbing pipe</a>. Based on these photos and Jessica's design, I sketched out some plans borrowing ideas from both.
 
-Next, I took an inventory of everything I would need to execute this plan and headed off to <a href="//www.lowes.com">Lowe's</a>. As Jessica noted, Lowe's will cut and thread the pipes for you right in the aisle. They also have pre-cut and pre-threaded pipes from about 1 inch through 20 inches in length.
+Next, I took an inventory of everything I would need to execute this plan and headed off to <a href="https://www.lowes.com">Lowe's</a>. As Jessica noted, Lowe's will cut and thread the pipes for you right in the aisle. They also have pre-cut and pre-threaded pipes from about 1 inch through 20 inches in length.
 
 ### Parts required to build the frame
 

--- a/src/_posts/legacy/2013-01-14-building-my-desk-part-one-the-frame.md
+++ b/src/_posts/legacy/2013-01-14-building-my-desk-part-one-the-frame.md
@@ -21,7 +21,7 @@ About a month ago, I stumbled upon <a href="http://spacekat.github.com">Jessica'
 
 Unlike Jessica's desk, I didn't want mine to be that of the standing variety.  I did some research and found <a href="http://www.apartmenttherapy.com/look-desks-and-68448">a few photos of other sitting desks that people had made out of plumbing pipe</a>. Based on these photos and Jessica's design, I sketched out some plans borrowing ideas from both.
 
-Next, I took an inventory of everything I would need to execute this plan and headed off to <a href="http://www.lowes.com">Lowe's</a>. As Jessica noted, Lowe's will cut and thread the pipes for you right in the aisle. They also have pre-cut and pre-threaded pipes from about 1 inch through 20 inches in length.
+Next, I took an inventory of everything I would need to execute this plan and headed off to <a href="//www.lowes.com">Lowe's</a>. As Jessica noted, Lowe's will cut and thread the pipes for you right in the aisle. They also have pre-cut and pre-threaded pipes from about 1 inch through 20 inches in length.
 
 ### Parts required to build the frame
 

--- a/src/feed.rss
+++ b/src/feed.rss
@@ -10,14 +10,10 @@
 		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		<lastBuildDate>{% for post in site.categories.microblog limit:1 %}{{ post.date | date_to_rfc822 }}{% endfor %}</lastBuildDate>
 		{% for post in site.posts %}
-                        {% unless post.categories contains "microblog" %}
+                        {% unless post.categories contains "microblog" or post.categories contains "legacy" %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>
-				{% if post.excerpt %}
-					<description>{{ post.excerpt | xml_escape }}</description>
-				{% else %}
-					<description>{{ post.content | xml_escape }}</description>
-				{% endif %}
+                                <description>{{ post.content | xml_escape }}</description>
 				<pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
 				<link>{{ site.url }}{{ post.url }}</link>
 				<guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>


### PR DESCRIPTION
Clean up RSS feed by
- Showing full post content (no truncated RSS)
- Removing old legacy posts from the feed